### PR TITLE
update track binning

### DIFF
--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -426,9 +426,9 @@ def make_fasta_file(genes, fasta_file):
 
 def main():
     args = parse_arguments()
-    print "hi from making files main() ", args.make
+    print "hi from making files main(); args.make is ", args.make
     if 'graph' in args.make:
-        print args.pickle_file
+        print "making_files.main() make 'graph': args.pickle_file " + args.pickle_file
         pham = cPickle.load(open(args.pickle_file.strip('"'), 'rb'))
         graph_start_sites(args, pham, args.dir)
 
@@ -446,7 +446,7 @@ def main():
         print "Load pickle file " + str(args.pickle_file)
         pham = cPickle.load(open(args.pickle_file.strip('"'), 'rb'))
         graph_start_sites(args, pham, args.dir)
-        print "phage", args.phage
+        print "making_files phage ", args.phage
         if not args.phage:
             print "hello no phage"
             make_pham_text(args, pham, args.pham_no, args.dir, only_pham=True)

--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -415,6 +415,7 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
         story.append(Paragraph(text, styles['Normal']))
         just_text.append(simple_text)
     doc.build(story)
+    print "writing text file"
     with open(text_file_name, 'w' ) as outfile:
         outfile.write("\n".join(just_text))
 

--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -387,15 +387,18 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
         {Gene Name} is a member of Pham {Number}: {Suggested Start Coordinates}
     """
     file_name = os.path.join(file_path, "%sSuggestedStarts.pdf" % (phage_name))
+    text_file_name = os.path.join(file_path, "%sSuggestedStarts.txt" % (phage_name))
     if check_file(file_name):
         return
     doc = SimpleDocTemplate(file_name, pagesize=reportlab.lib.pagesizes.letter)
     story = []
+    just_text = []
     print "making suggested starts page"
     styles = getSampleStyleSheet()
     styles.add(ParagraphStyle(name="paragraph"))
     styles.add(ParagraphStyle(name='Center', alignment=TA_CENTER))
     text = '<font size=14> Suggested Start Coordinates</font>'
+    just_text.append(' Suggested Start Coordinates')
     story.append(Paragraph(text, styles['Center']))
     story.append(Spacer(1, 12))
     for gene_id in sorted(phage_genes.iterkeys()):
@@ -405,10 +408,16 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
         suggested_start = phage_gene["suggested_start"]
         if pham == None:
             text = '<font size=12> %s is not a member of an existing Pham </font>' % (gene.gene_id)
+            simple_text = '%s is not a member of an existing Pham ' % (gene.gene_id)
         else:
             text = '<font size=12> %s is a member of Pham %s:  %s </font>' % (gene.gene_id, pham, suggested_start)
+            simple_text = '%s is a member of Pham %s:  %s ' % (gene.gene_id, pham, suggested_start)
         story.append(Paragraph(text, styles['Normal']))
+        just_text.append(simple_text)
     doc.build(story)
+    with open(text_file_name, 'w' ) as outfile:
+        outfile.write("\n".join(just_text))
+
 
 def make_fasta_file(genes, fasta_file):
     count = SeqIO.write(genes, fasta_file, 'fasta')

--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -247,14 +247,14 @@ def graph_start_sites(args, pham, file_path):
         final_graph_path = os.path.join(file_path, "Pham%sGraph_.pdf" % (pham.pham_no)) if not args.phage else os.path.join(file_path, "%sPham%sGraph_.pdf" % (args.phage+args.one_or_all, pham.pham_no))        
         # graph_path_svg = "%sPham%sGraph.svg" % (file_path+args.phage+ args.one_or_all, pham.pham_no)
         graph_path = os.path.join(file_path, "Pham%sGraph_.pdf" % (pham.pham_no)) if not args.phage else  os.path.join(file_path,"%sPham%sGraph_.pdf" % (args.phage, pham.pham_no))
-        print graph_path
+        print "making_files.graph_start_sites: path to graph is " + str(graph_path)
         if check_file(final_graph_path):
             pass
         else:
             gd_diagram = GenomeDiagram.Diagram(pham.pham_no)
             i = 0
             for gene_group in genes:
-                print 'group', i
+                print 'making_files.graph_start_sites: adding group ' + str(i)
                 make_gene_track(gd_diagram, pham, gene_group, i, len(genes))
                 i += 1
             gd_diagram.draw(format="linear", orientation="portrait", pagesize=reportlab.lib.pagesizes.letter,
@@ -426,7 +426,7 @@ def make_fasta_file(genes, fasta_file):
 
 def main():
     args = parse_arguments()
-    print "hi from making files main(); args.make is ", args.make
+    print "making_files:main(); args.make is ", args.make
     if 'graph' in args.make:
         print "making_files.main() make 'graph': args.pickle_file " + args.pickle_file
         pham = cPickle.load(open(args.pickle_file.strip('"'), 'rb'))
@@ -443,12 +443,12 @@ def main():
         make_suggested_starts(phage, args.phage, args.dir)
 
     if 'text' in args.make:
-        print "Load pickle file " + str(args.pickle_file)
+        print "making_files.main(): Loading pickle file " + str(args.pickle_file)
         pham = cPickle.load(open(args.pickle_file.strip('"'), 'rb'))
         graph_start_sites(args, pham, args.dir)
-        print "making_files phage ", args.phage
+        print "making_files.main(): 'text' phage is ", args.phage
         if not args.phage:
-            print "hello no phage"
+            print "making_files.main() 'text': no phage"
             make_pham_text(args, pham, args.pham_no, args.dir, only_pham=True)
         else:
             make_pham_text(args, pham, args.pham_no, args.dir)

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -338,6 +338,9 @@ class PhamGene(Gene):
             (amount of sequence before the previous stop site) is the same, if the candidate
             starts of the genes are the same, and if the alignment gaps or not are the same
             (This is essentially, they would look the same on the graph output)
+
+            TODO currenly only "is_equal" if the start coordinate is the identical base coordinate
+            would make sense to compare the annotated start index
         """
         if self.start != other.start:
             return False
@@ -351,6 +354,7 @@ class PhamGene(Gene):
         self.sequence.features.sort()
         other.sequence.features.sort()
         for feature1, feature2 in zip(self.sequence.features, other.sequence.features):
+            print "phamgene.is_equal comparing features"
             if feature1.location.start != feature2.location.start:
                 return False
             if feature1.location.end != feature2.location.end:

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -339,10 +339,10 @@ class PhamGene(Gene):
             starts of the genes are the same, and if the alignment gaps or not are the same
             (This is essentially, they would look the same on the graph output)
 
-            TODO currenly only "is_equal" if the start coordinate is the identical base coordinate
+            TODO currently only "is_equal" if the start coordinate is the identical base coordinate
             would make sense to compare the annotated start index
         """
-        if self.start != other.start:
+        if self.alignment_start_site != other.alignment_start_site:
             return False
         if self.ahead_of_start != other.ahead_of_start:
             return False

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -164,8 +164,7 @@ def new_PhamGene(db_id, start, stop, orientation, phage_id, phage_sequence=None)
     if db_id == None:
         return UnPhamGene(db_id, start, stop, orientation, phage_id, phage_sequence)
     if pham_genes.get(db_id, True):
-        pham_genes[db_id] = PhamGene(db_id, start, stop,
-                                 orientation, phage_id)
+        pham_genes[db_id] = PhamGene(db_id, start, stop, orientation, phage_id)
     return pham_genes[db_id]
 
 def get_gene_number(gene_name):

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -208,7 +208,9 @@ class PhamGene(Gene):
 
     def make_gene(self):
         """
-           makes the gene 
+           makes the gene which is a SeqRecord from Biopython. In this case the "gene" should
+           include all the sequence upstream of the annotated start all the way to the first
+           in frame stop codon.
         """
         phage = new_phage(phage_id=self.phage_id)
         self.phage_name = phage.get_name()

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -110,7 +110,7 @@ def find_upstream_stop_site(start, stop, orientation, phage_sequence):
         ahead_of_start += 99
         if orientation == 'R':
             if start + ahead_of_start > len(phage_sequence):     #i.e. hit end of phage while looking for stop
-                ahead_of_start = len(phage_sequence) - start
+                ahead_of_start = len(phage_sequence) - start -1  # start is zero based counting
                 ahead_of_start = ahead_of_start - ahead_of_start % 3
                 sequence = Seq(phage_sequence[stop:(start+ahead_of_start)],
                                IUPAC.unambiguous_dna)

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -112,7 +112,7 @@ def find_upstream_stop_site(start, stop, orientation, phage_sequence):
             if start + ahead_of_start > len(phage_sequence):     #i.e. hit end of phage while looking for stop
                 ahead_of_start = len(phage_sequence) - start -1  # start is zero based counting
                 ahead_of_start = ahead_of_start - ahead_of_start % 3
-                sequence = Seq(phage_sequence[stop:(start+ahead_of_start)],
+                sequence = Seq(phage_sequence[stop:(start+ahead_of_start+1)],
                                IUPAC.unambiguous_dna)
                 sequence = sequence.reverse_complement()
                 return sequence, ahead_of_start

--- a/starterator/phams.py
+++ b/starterator/phams.py
@@ -225,7 +225,7 @@ class Pham(object):
         start_stats["most_not_called"] = []
         start_stats["no_most_called"] = []
         genes_without_most_called = []
-        print genes_start_most_called
+        print "phams.find_most_common_start: genes_start_most_called " + str(genes_start_most_called)
         for gene in self.genes.values():
             if gene.gene_id in start_stats["possible"][most_called_start_index]:
                 if gene.gene_id in genes_start_most_called:

--- a/starterator/uiStarterate.py
+++ b/starterator/uiStarterate.py
@@ -191,9 +191,9 @@ class StarteratorEnterInformation(Gtk.Dialog):
         db = self.db_connect()
         phamgene.check_protein_db(self.config_info['count'])
         phage_name = self.find_phage_in_db(db, str(self.info['phage']))
-        print 'uiStarterate.starterate new phage name', self.info['phage']
-        print 'phamerated is ', self.info['phamerated']
-        print 'self.info.all is ', self.info['all']
+        print 'uiStarterate.starterate new phage, name is ', self.info['phage']
+        print 'uiStarterate.starterate phamerated is ', self.info['phamerated']
+        print 'uiStarterate.starterate self.info.all is ', self.info['all']
         if phage_name == None and self.info["phamerated"] and not self.info["pham"]:
             self.phameratored_exception(self.info["phage"])
             return
@@ -330,7 +330,7 @@ class StarteratorThread(threading.Thread):
                 # clean up files?
                 # show dialog
                 return
-            print 'help after starterator finished'
+            print 'uiStarterate.starterate openning dialog after starterator finished'
             Gdk.threads_enter()
             done_dialog = StarteratorFinishedDialog(self.parent, self.final_file)
             response = done_dialog.run()

--- a/starterator/uiStarterate.py
+++ b/starterator/uiStarterate.py
@@ -191,9 +191,9 @@ class StarteratorEnterInformation(Gtk.Dialog):
         db = self.db_connect()
         phamgene.check_protein_db(self.config_info['count'])
         phage_name = self.find_phage_in_db(db, str(self.info['phage']))
-        print 'new phage name', self.info['phage']
-        print 'phamerated', self.info['phamerated']
-        print 'all', self.info['all']
+        print 'uiStarterate.starterate new phage name', self.info['phage']
+        print 'phamerated is ', self.info['phamerated']
+        print 'self.info.all is ', self.info['all']
         if phage_name == None and self.info["phamerated"] and not self.info["pham"]:
             self.phameratored_exception(self.info["phage"])
             return


### PR DESCRIPTION
This increase track binning, old method required exact match of start coordinate in genome. New method just requires same start number.

examples 
pham 40 22 tracks -> 13 tracks
pham 9297   355 tracks -> 169 tracks
pham 3880 78 tracks  -> 24 tracks
